### PR TITLE
chore: promote golang-test to version 0.0.1

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,5 +7,8 @@ releases:
 - chart: dev/python-test
   version: 0.0.2
   name: python-test
+- chart: dev/golang-test
+  version: 0.0.1
+  name: golang-test
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote golang-test to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
